### PR TITLE
Fix cached interpreter execution mode not being able to be enabled

### DIFF
--- a/src/duckstation-libretro/libretro_core_options.h
+++ b/src/duckstation-libretro/libretro_core_options.h
@@ -283,7 +283,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "console",
       {
          { "Interpreter",      NULL },
-         { "CachedIntepreter", "Cached Interpreter" },
+         { "CachedInterpreter", "Cached Interpreter" },
          { "Recompiler",       NULL },
          { NULL, NULL },
       },


### PR DESCRIPTION
Due to a typo, it's impossible to actually use cached interpreter mode. Trying to enable it results in recompiler being used instead.