### PR TITLE
Add CHD precache support

### DIFF
--- a/src/common/cd_image.cpp
+++ b/src/common/cd_image.cpp
@@ -6,7 +6,7 @@
 #include <array>
 Log_SetChannel(CDImage);
 
-CDImage::CDImage() = default;
+CDImage::CDImage(OpenFlags open_flags) : m_open_flags(open_flags) {}
 
 CDImage::~CDImage() = default;
 
@@ -16,7 +16,7 @@ u32 CDImage::GetBytesPerSector(TrackMode mode)
   return sizes[static_cast<u32>(mode)];
 }
 
-std::unique_ptr<CDImage> CDImage::Open(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::Open(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
   const char* extension;
 
@@ -38,36 +38,36 @@ std::unique_ptr<CDImage> CDImage::Open(const char* filename, Common::Error* erro
 
   if (StringUtil::Strcasecmp(extension, ".cue") == 0)
   {
-    return OpenCueSheetImage(filename, error);
+    return OpenCueSheetImage(filename, open_flags, error);
   }
   else if (StringUtil::Strcasecmp(extension, ".bin") == 0 || StringUtil::Strcasecmp(extension, ".img") == 0 ||
            StringUtil::Strcasecmp(extension, ".iso") == 0)
   {
-    return OpenBinImage(filename, error);
+    return OpenBinImage(filename, open_flags, error);
   }
   else if (StringUtil::Strcasecmp(extension, ".chd") == 0)
   {
-    return OpenCHDImage(filename, error);
+    return OpenCHDImage(filename, open_flags, error);
   }
   else if (StringUtil::Strcasecmp(extension, ".ecm") == 0)
   {
-    return OpenEcmImage(filename, error);
+    return OpenEcmImage(filename, open_flags, error);
   }
   else if (StringUtil::Strcasecmp(extension, ".mds") == 0)
   {
-    return OpenMdsImage(filename, error);
+    return OpenMdsImage(filename, open_flags, error);
   }
   else if (StringUtil::Strcasecmp(extension, ".pbp") == 0)
   {
-    return OpenPBPImage(filename, error);
+    return OpenPBPImage(filename, open_flags, error);
   }
   else if (StringUtil::Strcasecmp(extension, ".m3u") == 0)
   {
-    return OpenM3uImage(filename, error);
+    return OpenM3uImage(filename, open_flags, error);
   }
 
   if (IsDeviceName(filename))
-    return OpenDeviceImage(filename, error);
+    return OpenDeviceImage(filename, open_flags, error);
 
 #undef CASE_COMPARE
 

--- a/src/common/cd_image.h
+++ b/src/common/cd_image.h
@@ -15,7 +15,13 @@ class Error;
 class CDImage
 {
 public:
-  CDImage();
+  enum class OpenFlags : u8
+  {
+    None = 0,
+    PreCache = (1 << 0), // Pre-cache image to RAM, if supported.
+  };
+
+  CDImage(OpenFlags open_flags);
   virtual ~CDImage();
 
   using LBA = u32;
@@ -210,18 +216,19 @@ public:
   static bool IsDeviceName(const char* filename);
 
   // Opening disc image.
-  static std::unique_ptr<CDImage> Open(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenBinImage(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenCueSheetImage(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenCHDImage(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenEcmImage(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenMdsImage(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenPBPImage(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenM3uImage(const char* filename, Common::Error* error);
-  static std::unique_ptr<CDImage> OpenDeviceImage(const char* filename, Common::Error* error);
+  static std::unique_ptr<CDImage> Open(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenBinImage(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenCueSheetImage(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenCHDImage(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenEcmImage(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenMdsImage(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenPBPImage(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenM3uImage(const char* filename, OpenFlags open_flags, Common::Error* error);
+  static std::unique_ptr<CDImage> OpenDeviceImage(const char* filename, OpenFlags open_flags, Common::Error* error);
   static std::unique_ptr<CDImage>
   CreateMemoryImage(CDImage* image, ProgressCallback* progress = ProgressCallback::NullProgressCallback);
-  static std::unique_ptr<CDImage> OverlayPPFPatch(const char* filename, std::unique_ptr<CDImage> parent_image,
+  static std::unique_ptr<CDImage> OverlayPPFPatch(const char* filename, OpenFlags open_flags,
+                                                  std::unique_ptr<CDImage> parent_image,
                                                   ProgressCallback* progress = ProgressCallback::NullProgressCallback);
 
   // Accessors.
@@ -248,6 +255,7 @@ public:
   const std::vector<Index>& GetIndices() const { return m_indices; }
   const Track& GetTrack(u32 track) const;
   const Index& GetIndex(u32 i) const;
+  OpenFlags GetOpenFlags() const { return m_open_flags; }
 
   // Seek to data LBA.
   bool Seek(LBA lba);
@@ -324,4 +332,8 @@ private:
   const Index* m_current_index = nullptr;
   LBA m_position_in_index = 0;
   LBA m_position_in_track = 0;
+
+  OpenFlags m_open_flags;
 };
+
+IMPLEMENT_ENUM_CLASS_BITWISE_OPERATORS(CDImage::OpenFlags);

--- a/src/common/cd_image_bin.cpp
+++ b/src/common/cd_image_bin.cpp
@@ -9,7 +9,7 @@ Log_SetChannel(CDImageBin);
 class CDImageBin : public CDImage
 {
 public:
-  CDImageBin();
+  CDImageBin(OpenFlags open_flags);
   ~CDImageBin() override;
 
   bool Open(const char* filename, Common::Error* error);
@@ -27,7 +27,7 @@ private:
   CDSubChannelReplacement m_sbi;
 };
 
-CDImageBin::CDImageBin() = default;
+CDImageBin::CDImageBin(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImageBin::~CDImageBin()
 {
@@ -133,9 +133,9 @@ bool CDImageBin::ReadSectorFromIndex(void* buffer, const Index& index, LBA lba_i
   return true;
 }
 
-std::unique_ptr<CDImage> CDImage::OpenBinImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenBinImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
-  std::unique_ptr<CDImageBin> image = std::make_unique<CDImageBin>();
+  std::unique_ptr<CDImageBin> image = std::make_unique<CDImageBin>(open_flags);
   if (!image->Open(filename, error))
     return {};
 

--- a/src/common/cd_image_cue.cpp
+++ b/src/common/cd_image_cue.cpp
@@ -14,7 +14,7 @@ Log_SetChannel(CDImageCueSheet);
 class CDImageCueSheet : public CDImage
 {
 public:
-  CDImageCueSheet();
+  CDImageCueSheet(OpenFlags open_flags);
   ~CDImageCueSheet() override;
 
   bool OpenAndParse(const char* filename, Common::Error* error);
@@ -37,7 +37,7 @@ private:
   CDSubChannelReplacement m_sbi;
 };
 
-CDImageCueSheet::CDImageCueSheet() = default;
+CDImageCueSheet::CDImageCueSheet(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImageCueSheet::~CDImageCueSheet()
 {
@@ -330,9 +330,9 @@ bool CDImageCueSheet::ReadSectorFromIndex(void* buffer, const Index& index, LBA 
   return true;
 }
 
-std::unique_ptr<CDImage> CDImage::OpenCueSheetImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenCueSheetImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
-  std::unique_ptr<CDImageCueSheet> image = std::make_unique<CDImageCueSheet>();
+  std::unique_ptr<CDImageCueSheet> image = std::make_unique<CDImageCueSheet>(open_flags);
   if (!image->OpenAndParse(filename, error))
     return {};
 

--- a/src/common/cd_image_device.cpp
+++ b/src/common/cd_image_device.cpp
@@ -66,7 +66,7 @@ static void DeinterleaveSubcode(const u8* subcode_in, u8* subcode_out)
 class CDImageDeviceWin32 : public CDImage
 {
 public:
-  CDImageDeviceWin32();
+  CDImageDeviceWin32(OpenFlags open_flags);
   ~CDImageDeviceWin32() override;
 
   bool Open(const char* filename, Common::Error* error);
@@ -101,7 +101,7 @@ private:
   std::array<u8, SUBCHANNEL_BYTES_PER_FRAME> m_subq;
 };
 
-CDImageDeviceWin32::CDImageDeviceWin32() = default;
+CDImageDeviceWin32::CDImageDeviceWin32(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImageDeviceWin32::~CDImageDeviceWin32()
 {
@@ -473,9 +473,9 @@ bool CDImageDeviceWin32::DetermineReadMode()
   return false;
 }
 
-std::unique_ptr<CDImage> CDImage::OpenDeviceImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenDeviceImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
-  std::unique_ptr<CDImageDeviceWin32> image = std::make_unique<CDImageDeviceWin32>();
+  std::unique_ptr<CDImageDeviceWin32> image = std::make_unique<CDImageDeviceWin32>(open_flags);
   if (!image->Open(filename, error))
     return {};
 
@@ -525,7 +525,7 @@ bool CDImage::IsDeviceName(const char* filename)
 
 #else
 
-std::unique_ptr<CDImage> CDImage::OpenDeviceImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenDeviceImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
   return {};
 }

--- a/src/common/cd_image_ecm.cpp
+++ b/src/common/cd_image_ecm.cpp
@@ -158,7 +158,7 @@ static void eccedc_generate(u8* sector, int type)
 class CDImageEcm : public CDImage
 {
 public:
-  CDImageEcm();
+  CDImageEcm(OpenFlags open_flags);
   ~CDImageEcm() override;
 
   bool Open(const char* filename, Common::Error* error);
@@ -213,7 +213,7 @@ private:
   CDSubChannelReplacement m_sbi;
 };
 
-CDImageEcm::CDImageEcm() = default;
+CDImageEcm::CDImageEcm(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImageEcm::~CDImageEcm()
 {
@@ -546,9 +546,9 @@ bool CDImageEcm::ReadSectorFromIndex(void* buffer, const Index& index, LBA lba_i
   return true;
 }
 
-std::unique_ptr<CDImage> CDImage::OpenEcmImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenEcmImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
-  std::unique_ptr<CDImageEcm> image = std::make_unique<CDImageEcm>();
+  std::unique_ptr<CDImageEcm> image = std::make_unique<CDImageEcm>(open_flags);
   if (!image->Open(filename, error))
     return {};
 

--- a/src/common/cd_image_m3u.cpp
+++ b/src/common/cd_image_m3u.cpp
@@ -13,7 +13,7 @@ Log_SetChannel(CDImageMemory);
 class CDImageM3u : public CDImage
 {
 public:
-  CDImageM3u();
+  CDImageM3u(OpenFlags open_flags);
   ~CDImageM3u() override;
 
   bool Open(const char* path, Common::Error* Error);
@@ -43,7 +43,7 @@ private:
   u32 m_current_image_index = UINT32_C(0xFFFFFFFF);
 };
 
-CDImageM3u::CDImageM3u() = default;
+CDImageM3u::CDImageM3u(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImageM3u::~CDImageM3u() = default;
 
@@ -130,7 +130,7 @@ bool CDImageM3u::SwitchSubImage(u32 index, Common::Error* error)
     return true;
 
   const Entry& entry = m_entries[index];
-  std::unique_ptr<CDImage> new_image = CDImage::Open(entry.filename.c_str(), error);
+  std::unique_ptr<CDImage> new_image = CDImage::Open(entry.filename.c_str(), GetOpenFlags(), error);
   if (!new_image)
   {
     Log_ErrorPrintf("Failed to load subimage %u (%s)", index, entry.filename.c_str());
@@ -173,9 +173,9 @@ bool CDImageM3u::ReadSubChannelQ(SubChannelQ* subq, const Index& index, LBA lba_
   return m_current_image->ReadSubChannelQ(subq, index, lba_in_index);
 }
 
-std::unique_ptr<CDImage> CDImage::OpenM3uImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenM3uImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
-  std::unique_ptr<CDImageM3u> image = std::make_unique<CDImageM3u>();
+  std::unique_ptr<CDImageM3u> image = std::make_unique<CDImageM3u>(open_flags);
   if (!image->Open(filename, error))
     return {};
 

--- a/src/common/cd_image_mds.cpp
+++ b/src/common/cd_image_mds.cpp
@@ -32,7 +32,7 @@ static_assert(sizeof(TrackEntry) == 0x50, "TrackEntry is 0x50 bytes");
 class CDImageMds : public CDImage
 {
 public:
-  CDImageMds();
+  CDImageMds(OpenFlags open_flags);
   ~CDImageMds() override;
 
   bool OpenAndParse(const char* filename, Common::Error* error);
@@ -49,7 +49,7 @@ private:
   CDSubChannelReplacement m_sbi;
 };
 
-CDImageMds::CDImageMds() = default;
+CDImageMds::CDImageMds(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImageMds::~CDImageMds()
 {
@@ -293,9 +293,9 @@ bool CDImageMds::ReadSectorFromIndex(void* buffer, const Index& index, LBA lba_i
   return true;
 }
 
-std::unique_ptr<CDImage> CDImage::OpenMdsImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenMdsImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
-  std::unique_ptr<CDImageMds> image = std::make_unique<CDImageMds>();
+  std::unique_ptr<CDImageMds> image = std::make_unique<CDImageMds>(open_flags);
   if (!image->OpenAndParse(filename, error))
     return {};
 

--- a/src/common/cd_image_memory.cpp
+++ b/src/common/cd_image_memory.cpp
@@ -10,7 +10,7 @@ Log_SetChannel(CDImageMemory);
 class CDImageMemory : public CDImage
 {
 public:
-  CDImageMemory();
+  CDImageMemory(OpenFlags open_flags);
   ~CDImageMemory() override;
 
   bool CopyImage(CDImage* image, ProgressCallback* progress);
@@ -27,7 +27,7 @@ private:
   CDSubChannelReplacement m_sbi;
 };
 
-CDImageMemory::CDImageMemory() = default;
+CDImageMemory::CDImageMemory(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImageMemory::~CDImageMemory()
 {
@@ -143,7 +143,7 @@ bool CDImageMemory::ReadSectorFromIndex(void* buffer, const Index& index, LBA lb
 std::unique_ptr<CDImage>
 CDImage::CreateMemoryImage(CDImage* image, ProgressCallback* progress /* = ProgressCallback::NullProgressCallback */)
 {
-  std::unique_ptr<CDImageMemory> memory_image = std::make_unique<CDImageMemory>();
+  std::unique_ptr<CDImageMemory> memory_image = std::make_unique<CDImageMemory>(image->GetOpenFlags());
   if (!memory_image->CopyImage(image, progress))
     return {};
 

--- a/src/common/cd_image_pbp.cpp
+++ b/src/common/cd_image_pbp.cpp
@@ -20,7 +20,7 @@ using FileSystem::FTell64;
 class CDImagePBP final : public CDImage
 {
 public:
-  CDImagePBP() = default;
+  CDImagePBP(OpenFlags open_flags) : CDImage(open_flags) {}
   ~CDImagePBP() override;
 
   bool Open(const char* filename, Common::Error* error);
@@ -898,9 +898,9 @@ std::string CDImagePBP::GetSubImageMetadata(u32 index, const std::string_view& t
   return CDImage::GetSubImageMetadata(index, type);
 }
 
-std::unique_ptr<CDImage> CDImage::OpenPBPImage(const char* filename, Common::Error* error)
+std::unique_ptr<CDImage> CDImage::OpenPBPImage(const char* filename, OpenFlags open_flags, Common::Error* error)
 {
-  std::unique_ptr<CDImagePBP> image = std::make_unique<CDImagePBP>();
+  std::unique_ptr<CDImagePBP> image = std::make_unique<CDImagePBP>(open_flags);
   if (!image->Open(filename, error))
     return {};
 

--- a/src/common/cd_image_ppf.cpp
+++ b/src/common/cd_image_ppf.cpp
@@ -18,7 +18,7 @@ enum : u32
 class CDImagePPF : public CDImage
 {
 public:
-  CDImagePPF();
+  CDImagePPF(OpenFlags open_flags);
   ~CDImagePPF() override;
 
   bool Open(const char* filename, std::unique_ptr<CDImage> parent_image);
@@ -46,7 +46,7 @@ private:
   u32 m_replacement_offset = 0;
 };
 
-CDImagePPF::CDImagePPF() = default;
+CDImagePPF::CDImagePPF(OpenFlags open_flags) : CDImage(open_flags) {}
 
 CDImagePPF::~CDImagePPF() = default;
 
@@ -429,10 +429,10 @@ bool CDImagePPF::ReadSectorFromIndex(void* buffer, const Index& index, LBA lba_i
 }
 
 std::unique_ptr<CDImage>
-CDImage::OverlayPPFPatch(const char* filename, std::unique_ptr<CDImage> parent_image,
+CDImage::OverlayPPFPatch(const char* filename, OpenFlags open_flags, std::unique_ptr<CDImage> parent_image,
                          ProgressCallback* progress /* = ProgressCallback::NullProgressCallback */)
 {
-  std::unique_ptr<CDImagePPF> ppf_image = std::make_unique<CDImagePPF>();
+  std::unique_ptr<CDImagePPF> ppf_image = std::make_unique<CDImagePPF>(open_flags);
   if (!ppf_image->Open(filename, std::move(parent_image)))
     return {};
 

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -556,6 +556,7 @@ void HostInterface::SetDefaultSettings(SettingsInterface& si)
   si.SetIntValue("CDROM", "ReadaheadSectors", Settings::DEFAULT_CDROM_READAHEAD_SECTORS);
   si.SetBoolValue("CDROM", "RegionCheck", false);
   si.SetBoolValue("CDROM", "LoadImageToRAM", false);
+  si.SetBoolValue("CDROM", "PreCacheCHD", false);
   si.SetBoolValue("CDROM", "MuteCDAudio", false);
   si.SetIntValue("CDROM", "ReadSpeedup", 1);
   si.SetIntValue("CDROM", "SeekSpeedup", 1);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -250,6 +250,7 @@ void Settings::Load(SettingsInterface& si)
   cdrom_readahead_sectors = static_cast<u8>(si.GetIntValue("CDROM", "ReadaheadSectors", DEFAULT_CDROM_READAHEAD_SECTORS));
   cdrom_region_check = si.GetBoolValue("CDROM", "RegionCheck", false);
   cdrom_load_image_to_ram = si.GetBoolValue("CDROM", "LoadImageToRAM", false);
+  cdrom_precache_chd = si.GetBoolValue("CDROM", "PreCacheCHD", false);
   cdrom_mute_cd_audio = si.GetBoolValue("CDROM", "MuteCDAudio", false);
   cdrom_read_speedup = si.GetIntValue("CDROM", "ReadSpeedup", 1);
   cdrom_seek_speedup = si.GetIntValue("CDROM", "SeekSpeedup", 1);
@@ -434,6 +435,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetIntValue("CDROM", "ReadaheadSectors", cdrom_readahead_sectors);
   si.SetBoolValue("CDROM", "RegionCheck", cdrom_region_check);
   si.SetBoolValue("CDROM", "LoadImageToRAM", cdrom_load_image_to_ram);
+  si.SetBoolValue("CDROM", "PreCacheCHD", cdrom_precache_chd);
   si.SetBoolValue("CDROM", "MuteCDAudio", cdrom_mute_cd_audio);
   si.SetIntValue("CDROM", "ReadSpeedup", cdrom_read_speedup);
   si.SetIntValue("CDROM", "SeekSpeedup", cdrom_seek_speedup);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -160,6 +160,7 @@ struct Settings
   u8 cdrom_readahead_sectors = DEFAULT_CDROM_READAHEAD_SECTORS;
   bool cdrom_region_check = false;
   bool cdrom_load_image_to_ram = false;
+  bool cdrom_precache_chd = false;
   bool cdrom_mute_cd_audio = false;
   u32 cdrom_read_speedup = 1;
   u32 cdrom_seek_speedup = 1;

--- a/src/duckstation-libretro/libretro_core_options.h
+++ b/src/duckstation-libretro/libretro_core_options.h
@@ -214,6 +214,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "false"
    },
    {
+      "duckstation_CDROM.PreCacheCHD",
+      "Pre-cache CHD Images To RAM",
+      NULL,
+      "Pre-caches CHD CD-ROM images to RAM without decompressing them. Unlike the preload option, this option supports "
+      "M3U files. It is also faster and requires less RAM compared to preloading as it doesn't decompress the CHD.",
+      NULL,
+      "console",
+      {
+         { "true",  "Enabled" },
+         { "false", "Disabled" },
+         { NULL, NULL },
+      },
+      "false"
+   },
+   {
       "duckstation_CDROM.MuteCDAudio",
       "Mute CD Audio",
       NULL,

--- a/src/duckstation-libretro/libretro_host_interface.cpp
+++ b/src/duckstation-libretro/libretro_host_interface.cpp
@@ -782,6 +782,7 @@ bool LibretroHostInterface::UpdateCoreOptionsDisplay()
   static bool pgxp_enable_prev;
   static MultitapMode multitap_mode_prev;
   static bool vram_rewrite_replacements_prev;
+  static bool cdrom_preload_enable_prev;
 
   const CPUExecutionMode cpu_execution_mode =
     Settings::ParseCPUExecutionMode(
@@ -806,15 +807,18 @@ bool LibretroHostInterface::UpdateCoreOptionsDisplay()
   const bool dual_multitap = (multitap_mode == MultitapMode::BothPorts);
 
   const bool vram_rewrite_replacements = (hardware_renderer && si.GetBoolValue("TextureReplacements", "EnableVRAMWriteReplacements", false));
+  const bool cdrom_preload_enable = si.GetBoolValue("CDROM", "LoadImageToRAM", false);
 
   if (cpu_execution_mode == cpu_execution_mode_prev && pgxp_enable == pgxp_enable_prev && 
-      multitap_mode == multitap_mode_prev && vram_rewrite_replacements == vram_rewrite_replacements_prev)
+      multitap_mode == multitap_mode_prev && vram_rewrite_replacements == vram_rewrite_replacements_prev &&
+      cdrom_preload_enable == cdrom_preload_enable_prev)
     return false;
 
   cpu_execution_mode_prev = cpu_execution_mode;
   pgxp_enable_prev = pgxp_enable;
   multitap_mode_prev = multitap_mode;
   vram_rewrite_replacements_prev = vram_rewrite_replacements;
+  cdrom_preload_enable_prev = cdrom_preload_enable;
 
   struct retro_core_option_display option_display;
 
@@ -910,6 +914,10 @@ bool LibretroHostInterface::UpdateCoreOptionsDisplay()
 
   option_display.visible = vram_rewrite_replacements;
   option_display.key = "duckstation_TextureReplacements.PreloadTextures";
+  g_retro_environment_callback(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+  option_display.visible = !cdrom_preload_enable;
+  option_display.key = "duckstation_CDROM.PreCacheCHD";
   g_retro_environment_callback(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
   return true;

--- a/src/duckstation-qt/consolesettingswidget.cpp
+++ b/src/duckstation-qt/consolesettingswidget.cpp
@@ -54,6 +54,7 @@ ConsoleSettingsWidget::ConsoleSettingsWidget(QtHostInterface* host_interface, QW
   SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.cdromRegionCheck, "CDROM", "RegionCheck", false);
   SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.cdromLoadImageToRAM, "CDROM", "LoadImageToRAM",
                                                false);
+  SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.cdromPreCacheCHD, "CDROM", "PreCacheCHD", false);
   SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.cdromLoadImagePatches, "CDROM",
                                                "LoadImagePatches", false);
   SettingWidgetBinder::BindWidgetToIntSetting(m_host_interface, m_ui.cdromSeekSpeedup, "CDROM", "SeekSpeedup", 1);
@@ -97,6 +98,10 @@ ConsoleSettingsWidget::ConsoleSettingsWidget(QtHostInterface* host_interface, QW
     m_ui.cdromLoadImageToRAM, tr("Preload Image to RAM"), tr("Unchecked"),
     tr("Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some "
        "cases also eliminates stutter when games initiate audio track playback."));
+  dialog->registerWidgetHelp(
+    m_ui.cdromPreCacheCHD, tr("Pre-cache CHD Images"), tr("Unchecked"),
+    tr("Pre-caches CHD CD-ROM images to RAM without decompressing them. Unlike the preload option, this option supports "
+       "M3U files. It is also faster and requires less RAM compared to preloading as it doesn't decompress the CHD."));
   dialog->registerWidgetHelp(m_ui.cdromLoadImagePatches, tr("Apply Image Patches"), tr("Unchecked"),
                              tr("Automatically applies patches to disc images when they are present in the same "
                                 "directory. Currently only PPF patches are supported with this option."));
@@ -113,10 +118,13 @@ ConsoleSettingsWidget::ConsoleSettingsWidget(QtHostInterface* host_interface, QW
   connect(m_ui.cpuClockSpeed, &QSlider::valueChanged, this, &ConsoleSettingsWidget::onCPUClockSpeedValueChanged);
   connect(m_ui.cdromReadSpeedup, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &ConsoleSettingsWidget::onCDROMReadSpeedupValueChanged);
+  connect(m_ui.cdromLoadImageToRAM, &QCheckBox::stateChanged, this,
+          &ConsoleSettingsWidget::updateCdromPreCacheCHDEnabled);
   connect(m_ui.multitapMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
           [this](int index) { emit multitapModeChanged(); });
 
   calculateCPUClockValue();
+  updateCdromPreCacheCHDEnabled();
 }
 
 ConsoleSettingsWidget::~ConsoleSettingsWidget() = default;
@@ -170,6 +178,11 @@ void ConsoleSettingsWidget::onCDROMReadSpeedupValueChanged(int value)
 {
   m_host_interface->SetIntSettingValue("CDROM", "ReadSpeedup", value + 1);
   m_host_interface->applySettings();
+}
+
+void ConsoleSettingsWidget::updateCdromPreCacheCHDEnabled()
+{
+  m_ui.cdromPreCacheCHD->setEnabled(!m_ui.cdromLoadImageToRAM->isChecked());
 }
 
 void ConsoleSettingsWidget::calculateCPUClockValue()

--- a/src/duckstation-qt/consolesettingswidget.h
+++ b/src/duckstation-qt/consolesettingswidget.h
@@ -23,6 +23,7 @@ private Q_SLOTS:
   void onCPUClockSpeedValueChanged(int value);
   void updateCPUClockSpeedLabel();
   void onCDROMReadSpeedupValueChanged(int value);
+  void updateCdromPreCacheCHDEnabled();
 
 private:
   void calculateCPUClockValue();

--- a/src/duckstation-qt/consolesettingswidget.ui
+++ b/src/duckstation-qt/consolesettingswidget.ui
@@ -272,13 +272,6 @@
       </item>
       <item row="3" column="0" colspan="2">
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="cdromRegionCheck">
-          <property name="text">
-           <string>Enable Region Check</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QCheckBox" name="cdromLoadImageToRAM">
           <property name="text">
@@ -286,10 +279,24 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="cdromRegionCheck">
+          <property name="text">
+           <string>Enable Region Check</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
          <widget class="QCheckBox" name="cdromLoadImagePatches">
           <property name="text">
            <string>Apply Image Patches</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cdromPreCacheCHD">
+          <property name="text">
+           <string>Pre-cache CHD Images</string>
           </property>
          </widget>
         </item>

--- a/src/duckstation-qt/gamepropertiesdialog.cpp
+++ b/src/duckstation-qt/gamepropertiesdialog.cpp
@@ -62,7 +62,7 @@ void GamePropertiesDialog::populate(const GameListEntry* ge)
   const QString title_qstring(QString::fromStdString(ge->title));
 
   std::string hash_code;
-  std::unique_ptr<CDImage> cdi(CDImage::Open(ge->path.c_str(), nullptr));
+  std::unique_ptr<CDImage> cdi(CDImage::Open(ge->path.c_str(), CDImage::OpenFlags::None, nullptr));
   if (cdi)
   {
     hash_code = System::GetGameHashCodeForImage(cdi.get());
@@ -253,7 +253,7 @@ void GamePropertiesDialog::populateTracksInfo(const std::string& image_path)
   m_ui.tracks->clearContents();
   m_path = image_path;
 
-  std::unique_ptr<CDImage> image = CDImage::Open(image_path.c_str(), nullptr);
+  std::unique_ptr<CDImage> image = CDImage::Open(image_path.c_str(), CDImage::OpenFlags::None, nullptr);
   if (!image)
     return;
 
@@ -972,7 +972,7 @@ void GamePropertiesDialog::computeTrackHashes(std::string& redump_keyword)
   if (m_path.empty())
     return;
 
-  std::unique_ptr<CDImage> image = CDImage::Open(m_path.c_str(), nullptr);
+  std::unique_ptr<CDImage> image = CDImage::Open(m_path.c_str(), CDImage::OpenFlags::None, nullptr);
   if (!image)
     return;
 

--- a/src/frontend-common/cheevos.cpp
+++ b/src/frontend-common/cheevos.cpp
@@ -969,7 +969,7 @@ void GameChanged()
   if (path.empty() || s_game_path == path)
     return;
 
-  std::unique_ptr<CDImage> cdi = CDImage::Open(path.c_str(), nullptr);
+  std::unique_ptr<CDImage> cdi = CDImage::Open(path.c_str(), CDImage::OpenFlags::None, nullptr);
   if (!cdi)
   {
     Log_ErrorPrintf("Failed to open temporary CD image '%s'", path.c_str());
@@ -1002,7 +1002,7 @@ void GameChanged(const std::string& path, CDImage* image)
 
   if (image && image->HasSubImages() && image->GetCurrentSubImage() != 0)
   {
-    std::unique_ptr<CDImage> image_copy(CDImage::Open(image->GetFileName().c_str(), nullptr));
+    std::unique_ptr<CDImage> image_copy(CDImage::Open(image->GetFileName().c_str(), CDImage::OpenFlags::None, nullptr));
     if (!image_copy)
     {
       Log_ErrorPrintf("Failed to reopen image '%s'", image->GetFileName().c_str());

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -1585,6 +1585,10 @@ void DrawSettingsWindow()
           "Preload Images to RAM",
           "Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay.",
           &s_settings_copy.cdrom_load_image_to_ram);
+        settings_changed |= ToggleButton(
+          "Pre-cache CHD Images",
+          "Pre-caches CHD images to RAM without decompressing them.",
+          &s_settings_copy.cdrom_precache_chd);
         settings_changed |= ToggleButtonForNonSetting(
           "Apply Image Patches",
           "Automatically applies patches to disc images when they are present, currently only PPF is supported.",

--- a/src/frontend-common/game_list.cpp
+++ b/src/frontend-common/game_list.cpp
@@ -146,7 +146,7 @@ bool GameList::GetGameListEntry(const std::string& path, GameListEntry* entry)
   if (System::IsPsfFileName(path.c_str()))
     return GetPsfListEntry(path.c_str(), entry);
 
-  std::unique_ptr<CDImage> cdi = CDImage::Open(path.c_str(), nullptr);
+  std::unique_ptr<CDImage> cdi = CDImage::Open(path.c_str(), CDImage::OpenFlags::None, nullptr);
   if (!cdi)
     return false;
 


### PR DESCRIPTION
This uses the chd_precache() function of libchdr which just loads the
CHD image to memory without decompressing it. So this is "weaker" than
the full preload to RAM option, which fully decompresses the CHD image,
but it still solves the problem of having the CHD images stored on
unreliable network storage. It's also much faster, since CHDs are quite
slow to decompress in whole.

The main point of this is to be able to use M3U files to run multi-disc
games and still be able to work around unreliable storage. The full
preload to RAM option does not work with M3U files. This option does.

CHD precache is ignored (and the option disabled in the UI) if the full
preload to RAM option is enabled.