### PR TITLE
Don't submit audio samples to frontend multiple times mid-frame

### DIFF
--- a/src/libretro/libretro_audio_stream.cpp
+++ b/src/libretro/libretro_audio_stream.cpp
@@ -1,9 +1,30 @@
 #include "libretro_audio_stream.h"
+#include "common/assert.h"
 #include "libretro_host_interface.h"
+#include <algorithm>
+#include <array>
 
 LibretroAudioStream::LibretroAudioStream() = default;
 
 LibretroAudioStream::~LibretroAudioStream() = default;
+
+void LibretroAudioStream::UploadToFrontend()
+{
+  std::array<SampleType, MaxSamples> output_buffer;
+  u32 total_samples = 0;
+
+  while (const auto num_samples = m_buffer.GetContiguousSize()) {
+    const auto write_pos = output_buffer.begin() + total_samples;
+    Assert(write_pos + num_samples <= output_buffer.end());
+
+    std::copy_n(m_buffer.GetReadPointer(), num_samples, write_pos);
+    m_buffer.Remove(num_samples);
+    total_samples += num_samples;
+  }
+
+  const auto total_frames = total_samples / m_channels;
+  g_retro_audio_sample_batch_callback(output_buffer.data(), total_frames);
+}
 
 bool LibretroAudioStream::OpenDevice()
 {
@@ -14,16 +35,4 @@ void LibretroAudioStream::PauseDevice(bool paused) {}
 
 void LibretroAudioStream::CloseDevice() {}
 
-void LibretroAudioStream::FramesAvailable()
-{
-  for (;;)
-  {
-    const u32 num_samples = m_buffer.GetContiguousSize();
-    if (num_samples == 0)
-      break;
-
-    const u32 num_frames = num_samples / m_channels;
-    g_retro_audio_sample_batch_callback(m_buffer.GetReadPointer(), num_frames);
-    m_buffer.Remove(num_samples);
-  }
-}
+void LibretroAudioStream::FramesAvailable() {}

--- a/src/libretro/libretro_audio_stream.h
+++ b/src/libretro/libretro_audio_stream.h
@@ -9,6 +9,8 @@ public:
   LibretroAudioStream();
   ~LibretroAudioStream();
 
+  void UploadToFrontend();
+
 protected:
   bool OpenDevice() override;
   void PauseDevice(bool paused) override;

--- a/src/libretro/libretro_host_interface.cpp
+++ b/src/libretro/libretro_host_interface.cpp
@@ -603,6 +603,10 @@ void LibretroHostInterface::retro_run_frame()
     UpdateGeometry();
 
   m_display->Render();
+
+  auto* const audio_stream = dynamic_cast<LibretroAudioStream*>(m_audio_stream.get());
+  DebugAssert(audio_stream);
+  audio_stream->UploadToFrontend();
 }
 
 unsigned LibretroHostInterface::retro_get_region()


### PR DESCRIPTION
The core is submitting audio samples to the frontend in multiple calls
before the current video frame loop has finished. This is a bad idea, as
the retro_audio_sample_batch_t callback is a blocking call, since the
frontend performs audio sync.

When using a low audio latency setting in RetroArch (like 5ms), audio
dropouts can occur. It's also possible that input lag is increased,
since video frames are presented later than they could have. The calls
to retro_audio_sample_batch_t can block for over 10ms, unnecessarily
delaying video frame presentation.

This commit fixes the issue by submitting all accumulated audio samples
at the end of the current video frame. Since the rendered audio is
stored in a HeapFIFOQueue which is not contiguous, an extra buffer is
used to consolidate all samples into a contiguous buffer. The buffer is
a stack allocated std::array so there's no memory allocation involved.