### PR TITLE
Backport sahlberg/duckstation@449d5a3 - pbp: pstitleimg sections are allowed also for single disc games

### DIFF
--- a/src/common/cd_image_pbp.cpp
+++ b/src/common/cd_image_pbp.cpp
@@ -423,7 +423,36 @@ bool CDImagePBP::Open(const char* filename, Common::Error* error)
         break;
     }
 
-    if (m_disc_offsets.size() < 2)
+    // Multidisc games are stored inside the EBOOT.PBP file as:
+    //
+    // A)
+    // pstitleimg
+    // psisoimg
+    // psisoimg
+    // ...
+    //
+    // Single disk games can be stored in two different formats, with or
+    // without a pstitleimg section, i.e. as:
+    //
+    // B)
+    // pstitleimg
+    // psisoimg
+    //
+    // or:
+    //
+    // C)
+    // psisoimg
+    //
+    // (Files of type (B) are created by the pop-fe utility,
+    // https://github.com/sahlberg/pop-fe)
+    //
+    // Thus even though a 'multi-disc header' has been found, this may
+    // still be a single disk game. We therefore only flag an error if
+    // m_disc_offsets.size() is less than one.
+    //
+    // This PBP format analysis and error checking is the work of
+    // Ronnie Sahlberg <ronniesahlberg@gmail.com>, author of pop-fe.
+    if (m_disc_offsets.size() < 1)
     {
       Log_ErrorPrintf("Invalid number of discs (%u) in multi-disc PBP file", static_cast<u32>(m_disc_offsets.size()));
       return false;


### PR DESCRIPTION
At present, the core cannot load single-disk games in PBP format created by the pop-fe utility (https://github.com/sahlberg/pop-fe). This is because the core does not fully comply with the PBP specification - it assumes that files with a PSTITLEIMG section are always multi-disk games, and fails when only a single disk is found. This is incorrect.

The author of pop-fe fixed this issue here: https://github.com/sahlberg/duckstation/commit/449d5a30075395f1084254d8b1b892669f74c843. This PR just backports the fix.