### PR TITLE
Removed redundant "System reset." OSD

### DIFF
--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -93,7 +93,6 @@ bool HostInterface::BootSystem(std::shared_ptr<SystemBootParameters> parameters)
 void HostInterface::ResetSystem()
 {
   System::Reset();
-  AddOSDMessage(TranslateStdString("OSDMessage", "System reset."));
 }
 
 void HostInterface::PauseSystem(bool paused)


### PR DESCRIPTION
RetroArch already displays a 'Reset' on-screen display on restart. As seen here: https://imgur.com/Z06aUQP