### PR TITLE
Enable Load Devices from Save States by default

### DIFF
--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -978,7 +978,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "false", "Disabled" },
          { NULL, NULL },
       },
-      "false"
+      "true"
    },
    {
       "duckstation_MemoryCards.Card1Type",


### PR DESCRIPTION
Enables `Load Devices from Save States` by default to avoid the issues users have experienced where loading a save state causes the game to crash a few seconds later.