### PR TITLE
remove redundant check for the empty string in filename

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -398,10 +398,6 @@ std::string BuildRelativePath(const std::string_view& filename, const std::strin
 
 std::unique_ptr<ByteStream> OpenFile(const char* FileName, u32 Flags)
 {
-  // has a path
-  if (FileName[0] == '\0')
-    return nullptr;
-
   // TODO: Handle Android content URIs here.
 
   // forward to local file wrapper


### PR DESCRIPTION
The OS APIs will error in such a case, we don't need to manually look for this error.