### PR TITLE
remove dead <malloc.h> include

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -10,8 +10,6 @@
 #include <mach-o/dyld.h>
 #include <stdlib.h>
 #include <sys/param.h>
-#else
-#include <malloc.h>
 #endif
 
 #ifdef __FreeBSD__


### PR DESCRIPTION
This include is part of what currently prevents swanstation from compiling on OpenBSD.