### PR TITLE
only #include <malloc.h> if it exists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,9 @@ add_definitions("-DLIBRETRO=1")
 
 check_symbol_exists(mkstemp "stdlib.h" HAVE_MKSTEMP)
 check_symbol_exists(alloca "alloca.h" HAVE_ALLOCA_H)
+if(NOT HAVE_ALLOCA_H)
+  check_symbol_exists(alloca "malloc.h" HAVE_MALLOC_H)
+endif()
 configure_file("config.h.cmake" "config.h")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include "file_system.h"
 #include "byte_stream.h"
 #include "log.h"
@@ -11,7 +13,11 @@
 #include <stdlib.h>
 #include <sys/param.h>
 #else
-#include <malloc.h>
+// alloca() on Microsoft Windows. Be careful because the header differs wildly
+// between operating systems.
+#  ifdef HAVE_MALLOC_H
+#    include <malloc.h>
+#  endif
 #endif
 
 #ifdef __FreeBSD__

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -1,2 +1,3 @@
 #cmakedefine HAVE_MKSTEMP
 #cmakedefine HAVE_ALLOCA_H
+#cmakedefine HAVE_MALLOC_H


### PR DESCRIPTION
This has been compile tested on Windows 10, PostMarketOS, and Termux.