### PR TITLE
System Requirements: "anything made in YYYY or later"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SwanStation features include:
 
 ## System Requirements
  - A CPU faster than a potato. But it needs to be x86_64, AArch32/armv7, or AArch64/ARMv8, otherwise you won't get a recompiler and it'll be slow.
- - For the hardware renderers, a GPU capable of OpenGL 3.1/OpenGL ES 3.0/Direct3D 11 Feature Level 10.0 (or Vulkan 1.0) and above. So, basically anything made in the last 10 years or so.
+ - For the hardware renderers, a GPU capable of OpenGL 3.1/OpenGL ES 3.0/Direct3D 11 Feature Level 10.0 (or Vulkan 1.0) and above. So, basically anything made in 2013 or later.
 
 ### Region detection and BIOS images
 By default, SwanStation will emulate the region check present in the CD-ROM controller of the console. This means that when the region of the console does not match the disc, it will refuse to boot, giving a "Please insert PlayStation CD-ROM" message. SwanStation supports automatic detection disc regions, and if you set the console region to auto-detect as well, this should never be a problem.


### PR DESCRIPTION
"anything made in the last 10 years or so" is a relative time reference being pretty useless when unclear how current that page/readme is.

"anything made in YYYY or later" is more helpful because it will be reliably true at any time of reading.

Based on rough research I think the year in question is circa 2013. Please correct that if you know better.

Research:
- Desktop GPUs meeting D3D11 FL 10.0 or OpenGL 3.1 became common starting around 2009–2010.
- Mobile GPUs supporting OpenGL ES 3.0 appeared around 2013.
- Vulkan-capable devices were not widespread until 2016+, but since it's listed as an alternative, it's not necessarily the baseline.