### PR TITLE
Add missing `#include` to `string_util.h`.

### DIFF
--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <iomanip>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
The lack of this was causing a build error when compiling with MSYS2 MinGW Clang x64.

There were other build errors too, but those were caused by `offsetof` somehow not being constexpr, which I imagine is a Clang/MSYS2 bug.