### PR TITLE
Silence various compiler warnings.

### DIFF
--- a/src/common/bitfield.h
+++ b/src/common/bitfield.h
@@ -11,9 +11,6 @@
 template<typename BackingDataType, typename DataType, unsigned BitIndex, unsigned BitCount>
 struct BitField
 {
-  // We have to delete the copy assignment operator otherwise we can't use this class in anonymous structs/unions.
-  BitField& operator=(const BitField& rhs) = delete;
-
   ALWAYS_INLINE constexpr BackingDataType GetMask() const
   {
     return ((static_cast<BackingDataType>(~0)) >> (8 * sizeof(BackingDataType) - BitCount)) << BitIndex;

--- a/src/common/cd_image.cpp
+++ b/src/common/cd_image.cpp
@@ -317,24 +317,8 @@ void CDImage::ClearTOC()
 void CDImage::CopyTOC(const CDImage* image)
 {
   m_lba_count = image->m_lba_count;
-  decltype(m_indices)().swap(m_indices);
-  decltype(m_tracks)().swap(m_tracks);
-  m_indices.reserve(image->m_indices.size());
-  m_tracks.reserve(image->m_tracks.size());
-
-  // Damn bitfield copy constructor...
-  for (const Index& index : image->m_indices)
-  {
-    Index new_index;
-    std::memcpy(&new_index, &index, sizeof(new_index));
-    m_indices.push_back(new_index);
-  }
-  for (const Track& track : image->m_tracks)
-  {
-    Track new_track;
-    std::memcpy(&new_track, &track, sizeof(new_track));
-    m_tracks.push_back(new_track);
-  }
+  m_indices = image->m_indices;
+  m_tracks = image->m_tracks;
   m_current_index = nullptr;
   m_position_in_index = 0;
   m_position_in_track = 0;

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -573,8 +573,8 @@ static u32 RecursiveFindFiles(const char* OriginPath, const char* ParentPath, co
         // recurse into this directory
         if (ParentPath != nullptr)
         {
-          const char *recurseDir = StringUtil::StdStringFromFormat("%s\\%s", ParentPath, Path).c_str();
-          nFiles += RecursiveFindFiles(OriginPath, recurseDir, utf8_filename, Pattern, Flags, pResults);
+          std::string recursiveDir = StringUtil::StdStringFromFormat("%s\\%s", ParentPath, Path);
+          nFiles += RecursiveFindFiles(OriginPath, recursiveDir.c_str(), utf8_filename, Pattern, Flags, pResults);
         }
         else
           nFiles += RecursiveFindFiles(OriginPath, Path, utf8_filename, Pattern, Flags, pResults);

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -163,7 +163,7 @@ static ALWAYS_INLINE void FormatLogMessageAndPrintW(const char* channelName, con
   char* message_buf = buf;
   int message_len;
   if ((message_len = FormatLogMessageForDisplay(message_buf, sizeof(buf), channelName, functionName, level, message,
-                                                timestamp, ansi_color_code, newline)) > (sizeof(buf) - 1))
+                                                timestamp, ansi_color_code, newline)) > static_cast<int>(sizeof(buf) - 1))
   {
     message_buf = static_cast<char*>(std::malloc(message_len + 1));
     message_len = FormatLogMessageForDisplay(message_buf, message_len + 1, channelName, functionName, level, message,
@@ -177,7 +177,7 @@ static ALWAYS_INLINE void FormatLogMessageAndPrintW(const char* channelName, con
   wchar_t wbuf[512];
   wchar_t* wmessage_buf = wbuf;
   int wmessage_buflen = countof(wbuf) - 1;
-  if (message_len >= countof(wbuf))
+  if (message_len >= static_cast<int>(countof(wbuf)))
   {
     wmessage_buflen = message_len;
     wmessage_buf = static_cast<wchar_t*>(std::malloc((wmessage_buflen + 1) * sizeof(wchar_t)));

--- a/src/common/memory_arena.cpp
+++ b/src/common/memory_arena.cpp
@@ -127,7 +127,7 @@ bool MemoryArena::Create(size_t size, bool writable, bool executable)
 
 #if defined(_WIN32)
   const DWORD protect = (writable ? (executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE) : PAGE_READONLY);
-  m_file_handle = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, protect, Truncate32(size >> 32), Truncate32(size),
+  m_file_handle = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, protect, Truncate32(size >> 16 >> 16), Truncate32(size),
                                      file_mapping_name.c_str());
   if (!m_file_handle)
   {
@@ -250,7 +250,7 @@ void* MemoryArena::CreateViewPtr(size_t offset, size_t size, bool writable, bool
 #if defined(_WIN32)
   const DWORD desired_access = FILE_MAP_READ | (writable ? FILE_MAP_WRITE : 0) | (executable ? FILE_MAP_EXECUTE : 0);
   base_pointer =
-    MapViewOfFileEx(m_file_handle, desired_access, Truncate32(offset >> 32), Truncate32(offset), size, fixed_address);
+    MapViewOfFileEx(m_file_handle, desired_access, Truncate32(offset >> 16 >> 16), Truncate32(offset), size, fixed_address);
   if (!base_pointer)
     return nullptr;
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)

--- a/src/common/rectangle.h
+++ b/src/common/rectangle.h
@@ -49,7 +49,10 @@ struct Rectangle
   /// Assignment operator.
   constexpr Rectangle& operator=(const Rectangle& rhs)
   {
-    std::memcpy(this, &rhs, sizeof(Rectangle));
+    left = rhs.left;
+    top = rhs.top;
+    right = rhs.right;
+    bottom = rhs.bottom;
     return *this;
   }
 

--- a/src/common/vulkan/shader_cache.cpp
+++ b/src/common/vulkan/shader_cache.cpp
@@ -357,7 +357,7 @@ bool ShaderCache::FlushPipelineCache()
 
   // Save disk writes if it hasn't changed, think of the poor SSDs.
   int32_t sd_size = path_get_size(m_pipeline_cache_filename.c_str());
-  if (sd_size == -1 || sd_size != static_cast<u64>(data_size))
+  if (sd_size == -1 || static_cast<size_t>(sd_size) != data_size)
   {
     Log_InfoPrintf("Writing %zu bytes to '%s'", data_size, m_pipeline_cache_filename.c_str());
     if (!FileSystem::WriteBinaryFile(m_pipeline_cache_filename.c_str(), data.data(), data.size()))

--- a/src/core/cdrom.cpp
+++ b/src/core/cdrom.cpp
@@ -134,7 +134,7 @@ void CDROM::Reset()
   std::memset(&m_last_sector_header, 0, sizeof(m_last_sector_header));
   std::memset(&m_last_sector_subheader, 0, sizeof(m_last_sector_subheader));
   m_last_sector_header_valid = false;
-  std::memset(&m_last_subq, 0, sizeof(m_last_subq));
+  m_last_subq = {};
   m_last_cdda_report_frame_nibble = 0xFF;
 
   m_next_cd_audio_volume_matrix[0][0] = 0x80;

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -151,6 +151,10 @@ std::string HostInterface::GetBIOSDirectory()
 std::optional<std::vector<u8>> HostInterface::GetBIOSImage(ConsoleRegion region)
 {
   std::string bios_dir = GetBIOSDirectory();
+
+  if (bios_dir.empty())
+    return std::nullopt;
+
   std::string bios_name;
   switch (region)
   {

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -1324,7 +1324,7 @@ bool InjectEXEFromBuffer(const void* buffer, u32 buffer_size, bool patch_bios)
   std::memcpy(&header, buffer_ptr, sizeof(header));
   buffer_ptr += sizeof(header);
 
-  const u32 file_size = static_cast<u32>(static_cast<u32>(buffer_end - buffer_ptr));
+  const u32 file_size = static_cast<u32>(buffer_end - buffer_ptr);
   if (!BIOS::IsValidPSExeHeader(header, file_size))
     return false;
 
@@ -1343,7 +1343,7 @@ bool InjectEXEFromBuffer(const void* buffer, u32 buffer_size, bool patch_bios)
   if (file_data_size >= 4)
   {
     std::vector<u32> data_words((file_data_size + 3) / 4);
-    if ((buffer_end - buffer_ptr) < file_data_size)
+    if (file_size < file_data_size)
       return false;
 
     std::memcpy(data_words.data(), buffer_ptr, file_data_size);

--- a/src/libretro/libretro_host_interface.cpp
+++ b/src/libretro/libretro_host_interface.cpp
@@ -1061,7 +1061,7 @@ std::string LibretroHostInterface::GetBIOSDirectory()
   // Assume BIOS files are located in system directory.
   const char* system_directory = nullptr;
   if (!g_retro_environment_callback(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_directory))
-    return nullptr;
+    return {};
   return system_directory;
 }
 


### PR DESCRIPTION
Just a lot of signed-unsigned comparisons, memcpys/memsets of non-trivial objects, and other minor nitpicks.

Tested with GCC, Clang, and MSVC. All seem to build and run fine.