### PR TITLE
Refresh the frontend log callback after a reload

### DIFF
--- a/src/libretro/libretro_host_interface.cpp
+++ b/src/libretro/libretro_host_interface.cpp
@@ -241,6 +241,15 @@ static void LibretroLogCallback(void* pUserParam, const char* channelName, const
                               (level <= LogLevel::Perf) ? functionName : channelName, message);
 }
 
+static void ResetLibretroLogging()
+{
+  if (s_libretro_log_callback_registered)
+    Log::UnregisterCallback(LibretroLogCallback, nullptr);
+  s_libretro_log_callback = {};
+  s_libretro_log_callback_registered = false;
+  s_libretro_log_callback_valid = false;
+}
+
 HostInterface::HostInterface()
 {
   g_host_interface = this;
@@ -337,11 +346,11 @@ void HostInterface::InitInterfaces()
 
 void HostInterface::InitLogging()
 {
-  if (s_libretro_log_callback_registered)
-    return;
+  ResetLibretroLogging();
 
   s_libretro_log_callback_valid =
-    g_retro_environment_callback(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &s_libretro_log_callback);
+    g_retro_environment_callback(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &s_libretro_log_callback) &&
+    s_libretro_log_callback.log;
 
   if (s_libretro_log_callback_valid)
   {
@@ -361,6 +370,7 @@ bool HostInterface::Initialize()
   P_THIS->m_disk_control_info.image_paths.clear();
   P_THIS->m_disk_control_info.image_labels.clear();
 
+  InitLogging();
   InitInterfaces();
   LoadSettings();
   FixIncompatibleSettings(true);
@@ -386,6 +396,8 @@ void HostInterface::Shutdown()
   P_THIS->m_disk_control_info.sub_images_parent_path.clear();
   P_THIS->m_disk_control_info.image_paths.clear();
   P_THIS->m_disk_control_info.image_labels.clear();
+
+  ResetLibretroLogging();
 }
 
 void HostInterface::ReportError(const char* message)


### PR DESCRIPTION
## Description

Refresh the libretro frontend logging callback when the frontend is reloaded.

Kodi can replace its libretro frontend while leaving the core loaded. SwanStation retained the original frontend log callback across `retro_deinit()`, which could leave a stale function pointer when the next game started.

This change unregisters and clears the callback during shutdown, reacquires it during initialization, and handles frontends that do not provide a logging interface.

## How has this been tested?

Tested repeated frontend reloads with replaced and disabled log callbacks. Verified that:

* logging uses the current frontend callback
* each log event is delivered once
* no callbacks are invoked after shutdown
* existing disc tests continue to pass