### PR TITLE
Allow frontends to edit M3U playlists

### DIFF
--- a/src/libretro/libretro_host_interface.cpp
+++ b/src/libretro/libretro_host_interface.cpp
@@ -410,6 +410,11 @@ void HostInterface::GetGameInfo(const char* path, CDImage* image, std::string* c
 {
   // Just use the filename for now... we don't have the game list. Unless we can pull this from the frontend somehow?
   *title = FileSystem::GetFileTitleFromPath(path);
+  if (g_settings.memory_card_use_playlist_title && !m_disk_control_info.has_sub_images &&
+      !m_disk_control_info.sub_images_parent_path.empty())
+  {
+    *title = FileSystem::GetFileTitleFromPath(m_disk_control_info.sub_images_parent_path);
+  }
 
   if (image)
     *code = System::GetGameCodeForImage(image, true);
@@ -759,7 +764,8 @@ bool HostInterface::retro_load_game(const struct retro_game_info* game)
         return false;
       }
 
-      P_THIS->m_disk_control_info.has_sub_images         = true;
+      const char* extension = std::strrchr(parent_path.c_str(), '.');
+      P_THIS->m_disk_control_info.has_sub_images = !extension || StringUtil::Strcasecmp(extension, ".m3u") != 0;
       P_THIS->m_disk_control_info.image_index            = System::GetMediaSubImageIndex();
       P_THIS->m_disk_control_info.image_count            = System::GetMediaSubImageCount();
       P_THIS->m_disk_control_info.sub_images_parent_path = parent_path;


### PR DESCRIPTION
## Description

Allow frontends to add, replace and remove discs from M3U playlists.

M3U playlists were treated like immutable multi-disc container images, causing SwanStation to reject disk-control requests that modify the playlist. M3U entries are now opened as individual images while existing subimage handling is retained for actual multi-disc containers.

When `UsePlaylistTitle` is enabled, the original M3U filename is also preserved as the game title so disc changes continue using the same per-game memory card.

## Motivation and context

Frontends implementing the libretro extended disk-control interface need to be able to edit an M3U playlist at runtime. Previously these operations failed because M3U discs were exposed as subimages of a single image.

## How has this been tested?

Tested with the two-disc Metal Gear Solid M3U playlist:

* Added and removed disc images
* Reused previously removed images
* Removed every disc from the playlist
* Swapped discs and loaded save states
* Verified the playlist title and memory-card files remain consistent

## What is the effect on users?

Frontends can now modify M3U disc playlists at runtime, while games configured to use the playlist title continue sharing the correct memory card across disc changes.