### PR TITLE
Reject invalid disc metadata buffers

### DIFF
--- a/src/libretro/libretro_host_interface.cpp
+++ b/src/libretro/libretro_host_interface.cpp
@@ -2339,7 +2339,7 @@ bool HostInterface::DiskControlSetInitialImage(unsigned index, const char* path)
 
 bool HostInterface::DiskControlGetImagePath(unsigned index, char* path, size_t len)
 {
-  if ((index >= P_THIS->m_disk_control_info.image_count) ||
+  if (!path || len == 0 || (index >= P_THIS->m_disk_control_info.image_count) ||
       (index >= P_THIS->m_disk_control_info.image_paths.size()) ||
       P_THIS->m_disk_control_info.image_paths[index].empty())
     return false;
@@ -2350,7 +2350,7 @@ bool HostInterface::DiskControlGetImagePath(unsigned index, char* path, size_t l
 
 bool HostInterface::DiskControlGetImageLabel(unsigned index, char* label, size_t len)
 {
-  if ((index >= P_THIS->m_disk_control_info.image_count) ||
+  if (!label || len == 0 || (index >= P_THIS->m_disk_control_info.image_count) ||
       (index >= P_THIS->m_disk_control_info.image_labels.size()) ||
       P_THIS->m_disk_control_info.image_labels[index].empty())
     return false;


### PR DESCRIPTION
## Description

Validate output buffers in the libretro disk metadata callbacks before copying image paths or labels.

`DiskControlGetImagePath()` and `DiskControlGetImageLabel()` previously accepted null pointers and zero-length buffers. This could report success for unusable buffers or attempt to write through a null pointer when a nonzero length was supplied.

Both callbacks now reject missing buffers and zero lengths before calling `strlcpy()`.

## Motivation and context

The extended disk-control callbacks receive frontend-provided output buffers, so their pointer and size need to be validated before use.

## How has this been tested?

Tested both callbacks with:

* Null buffers
* Zero-length buffers
* One-byte buffers
* Invalid image indices
* Valid image paths and labels

## What is the effect on users?

Prevents invalid frontend metadata requests from causing incorrect success responses or unsafe memory access.