### PR TITLE
Support No Disc with a closed tray

### DIFF
--- a/src/core/cdrom.cpp
+++ b/src/core/cdrom.cpp
@@ -96,6 +96,7 @@ void CDROM::Initialize()
 
 void CDROM::Shutdown()
 {
+  m_shell_open = false;
   m_command_event.reset();
   m_command_second_response_event.reset();
   m_drive_event.reset();
@@ -112,7 +113,7 @@ void CDROM::Reset()
   m_status.bits = 0;
   m_secondary_status.bits = 0;
   m_secondary_status.motor_on = CanReadMedia();
-  m_secondary_status.shell_open = !CanReadMedia();
+  m_secondary_status.shell_open = m_shell_open;
   m_mode.bits = 0;
   m_mode.read_raw_sector = true;
   m_interrupt_enable_register = INTERRUPT_REGISTER_MASK;
@@ -170,7 +171,7 @@ void CDROM::SoftReset(TickCount ticks_late)
   ClearDriveState();
   m_secondary_status.bits = 0;
   m_secondary_status.motor_on = CanReadMedia();
-  m_secondary_status.shell_open = !CanReadMedia();
+  m_secondary_status.shell_open = m_shell_open;
   m_mode.bits = 0;
   m_mode.read_raw_sector = true;
   m_pending_async_interrupt = 0;
@@ -324,6 +325,7 @@ void CDROM::InsertMedia(std::unique_ptr<CDImage> media)
 {
   if (CanReadMedia())
     RemoveMedia(true);
+  m_shell_open = false;
 
   // set the region from the system area of the disc
   m_disc_region = System::GetRegionForImage(media.get());
@@ -338,8 +340,9 @@ void CDROM::InsertMedia(std::unique_ptr<CDImage> media)
 
 std::unique_ptr<CDImage> CDROM::RemoveMedia(bool for_disc_swap)
 {
-  if (!HasMedia())
+  if (!HasMedia() && m_shell_open)
     return nullptr;
+  m_shell_open = true;
 
   // Add an additional two seconds to the disc swap, some games don't like it happening too quickly.
   TickCount stop_ticks = GetTicksForStop(true);
@@ -865,7 +868,7 @@ void CDROM::ExecuteCommand(TickCount ticks_late)
       SendACKAndStat();
 
       // shell open bit is cleared after sending the status
-      if (CanReadMedia())
+      if (!m_shell_open && m_drive_state != DriveState::ShellOpening)
         m_secondary_status.shell_open = false;
 
       EndCommand();

--- a/src/core/cdrom.h
+++ b/src/core/cdrom.h
@@ -32,6 +32,7 @@ public:
 
   void InsertMedia(std::unique_ptr<CDImage> media);
   std::unique_ptr<CDImage> RemoveMedia(bool for_disc_swap);
+  void SetShellOpen(bool opened) { m_shell_open = opened; }
 
   void CPUClockChanged();
 
@@ -373,6 +374,8 @@ private:
   std::array<SectorBuffer, NUM_SECTOR_BUFFERS> m_sector_buffers;
 
   CDROMAsyncReader m_reader;
+  // The status bit stays latched until Getstat acknowledges a closed shell.
+  bool m_shell_open = false;
 
   // two 16-bit samples packed in 32-bits
   HeapFIFOQueue<uint32_t, AUDIO_FIFO_SIZE> m_audio_fifo;

--- a/src/core/host_interface.h
+++ b/src/core/host_interface.h
@@ -49,6 +49,7 @@ public:
   struct DiskControlInfo
   {
     bool has_sub_images;
+    bool ejected;
     uint32_t initial_image_index;
     uint32_t image_index;
     uint32_t image_count;

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -1600,6 +1600,12 @@ void RemoveMedia()
   ClearMemorySaveStates();
 }
 
+void SetMediaTrayOpen(bool opened)
+{
+  g_cdrom.SetShellOpen(opened);
+  ClearMemorySaveStates();
+}
+
 void UpdateRunningGame(const char* path, CDImage* image)
 {
   if (s_running_game_path == path)

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -117,6 +117,7 @@ bool HasMedia();
 std::string GetMediaFileName();
 bool InsertMedia(const char* path);
 void RemoveMedia();
+void SetMediaTrayOpen(bool opened);
 
 /// Returns true if this is a multi-subimage image (e.g. m3u).
 bool HasMediaSubImages();

--- a/src/libretro/libretro_host_interface.cpp
+++ b/src/libretro/libretro_host_interface.cpp
@@ -354,6 +354,7 @@ bool HostInterface::Initialize()
 {
   /* Reset disk control info struct */
   P_THIS->m_disk_control_info.has_sub_images      = false;
+  P_THIS->m_disk_control_info.ejected             = false;
   P_THIS->m_disk_control_info.initial_image_index = 0;
   P_THIS->m_disk_control_info.image_index         = 0;
   P_THIS->m_disk_control_info.image_count         = 0;
@@ -380,6 +381,7 @@ void HostInterface::Shutdown()
 
   /* Reset disk control info struct */
   P_THIS->m_disk_control_info.has_sub_images      = false;
+  P_THIS->m_disk_control_info.ejected             = false;
   P_THIS->m_disk_control_info.initial_image_index = 0;
   P_THIS->m_disk_control_info.image_index         = 0;
   P_THIS->m_disk_control_info.image_count         = 0;
@@ -704,6 +706,7 @@ bool HostInterface::retro_load_game(const struct retro_game_info* game)
   if (game && game->path)
     bp->filename = game->path;
   bp->media_playlist_index = P_THIS->m_disk_control_info.initial_image_index;
+  m_disk_control_info = {};
   bp->force_software_renderer = !m_hw_render_callback_valid;
 
   struct retro_input_descriptor desc[] = {
@@ -952,7 +955,12 @@ bool HostInterface::retro_unserialize(const void* data, size_t size)
   }
 
   std::unique_ptr<ByteStream> stream = ByteStream_CreateReadOnlyMemoryStream(data, static_cast<uint32_t>(size));
-  return System::LoadState(stream.get(), is_memory_state);
+  if (!System::LoadState(stream.get(), is_memory_state))
+    return false;
+
+  m_disk_control_info.ejected = !System::HasMedia();
+  System::SetMediaTrayOpen(m_disk_control_info.ejected);
+  return true;
 }
 
 void* HostInterface::retro_get_memory_data(unsigned id)
@@ -2202,54 +2210,52 @@ bool HostInterface::DiskControlSetEjectState(bool ejected)
   if (System::IsShutdown())
     return false;
 
+  DiskControlInfo& info = P_THIS->m_disk_control_info;
+  if (info.ejected == ejected)
+    return true;
+
   if (ejected)
   {
-    if (!System::HasMedia())
-      return false;
-
     System::RemoveMedia();
   }
-  else
+  else if (info.image_index < info.image_count)
   {
-    if (System::HasMedia())
-      return false;
-
-    if (P_THIS->m_disk_control_info.has_sub_images)
+    if (info.has_sub_images)
     {
-      if (!System::InsertMedia(P_THIS->m_disk_control_info.sub_images_parent_path.c_str()))
+      if (!System::InsertMedia(info.sub_images_parent_path.c_str()))
         return false;
-
-      if (!System::SwitchMediaSubImage(P_THIS->m_disk_control_info.image_index))
+      if (!System::SwitchMediaSubImage(info.image_index))
+      {
+        System::RemoveMedia();
         return false;
+      }
     }
-    else if (!System::InsertMedia(P_THIS->m_disk_control_info.image_paths[P_THIS->m_disk_control_info.image_index].c_str()))
+    else if (!System::InsertMedia(info.image_paths[info.image_index].c_str()))
       return false;
   }
 
+  info.ejected = ejected;
+  System::SetMediaTrayOpen(ejected);
   return true;
 }
 
 bool HostInterface::DiskControlGetEjectState()
 {
-  if (System::IsShutdown())
-    return false;
-
-  return !System::HasMedia();
+  return !System::IsShutdown() && P_THIS->m_disk_control_info.ejected;
 }
 
 unsigned HostInterface::DiskControlGetImageIndex()
 {
-  return (unsigned)P_THIS->m_disk_control_info.image_index;
+  return P_THIS->m_disk_control_info.image_index;
 }
 
 bool HostInterface::DiskControlSetImageIndex(unsigned index)
 {
-  if (System::IsShutdown() ||
-      System::HasMedia() ||
-      (index >= P_THIS->m_disk_control_info.image_count))
+  DiskControlInfo& info = P_THIS->m_disk_control_info;
+  if (System::IsShutdown() || !info.ejected || (index < info.image_count && info.image_paths[index].empty()))
     return false;
 
-  P_THIS->m_disk_control_info.image_index = (uint32_t)index;
+  info.image_index = std::min(index, info.image_count);
   return true;
 }
 
@@ -2266,8 +2272,7 @@ bool HostInterface::DiskControlReplaceImageIndex(unsigned index, const retro_gam
 #define CASE_COMPARE strcasecmp
 #endif
 
-  if (System::IsShutdown() ||
-      System::HasMedia() ||
+  if (System::IsShutdown() || !P_THIS->m_disk_control_info.ejected ||
       (index >= P_THIS->m_disk_control_info.image_count))
     return false;
 
@@ -2280,7 +2285,9 @@ bool HostInterface::DiskControlReplaceImageIndex(unsigned index, const retro_gam
     /* Remove specified image */
     P_THIS->m_disk_control_info.image_count--;
 
-    if (index < P_THIS->m_disk_control_info.image_index)
+    if (index == P_THIS->m_disk_control_info.image_index)
+      P_THIS->m_disk_control_info.image_index = P_THIS->m_disk_control_info.image_count;
+    else if (index < P_THIS->m_disk_control_info.image_index)
       P_THIS->m_disk_control_info.image_index--;
 
     P_THIS->m_disk_control_info.image_paths.erase(
@@ -2320,6 +2327,8 @@ bool HostInterface::DiskControlAddImageIndex()
   if (P_THIS->m_disk_control_info.has_sub_images)
     return false;
 
+  if (P_THIS->m_disk_control_info.image_index == P_THIS->m_disk_control_info.image_count)
+    P_THIS->m_disk_control_info.image_index++;
   P_THIS->m_disk_control_info.image_count++;
   P_THIS->m_disk_control_info.image_paths.push_back("");
   P_THIS->m_disk_control_info.image_labels.push_back("");


### PR DESCRIPTION
## Description

Support the libretro `No Disc` selection while the virtual CD tray is closed.

Previously, having no mounted image implicitly meant the tray was open. This prevented frontends from closing an empty drive and made the `No Disc` selection unstable when playlist entries were added or removed.

Track the tray state separately from media presence and normalize out-of-range image selections to the `No Disc` slot. Preserve that selection across list edits, reset disk-control state when loading another game, and synchronize the tray after loading a save state.

The CD-ROM shell state is also kept separate from the latched `Getstat` status so the existing disc-swap delay behavior is preserved.

## Motivation and context

The libretro disk-control interface allows a frontend to select no image while independently controlling the eject state. SwanStation previously conflated these two states, so an empty but closed drive could not be represented correctly.

## How has this been tested?

Tested:

* Single-CHD loads
* Two-disc Metal Gear Solid loads
* Empty-drive open/close transitions
* Removing and re-adding playlist entries
* Reloading games
* Loading existing open- and closed-tray save states
* `Getstat` behavior during subimage swaps

The patch builds and passes these checks against the upstream base without the other disk-control fixes.

## What is the effect on users?

Frontends can now leave the virtual CD drive closed with no disc inserted, and the `No Disc` selection remains stable when disc lists are edited or restored from save states.