### PR TITLE
Restore the selected disc when loading a state

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -79,7 +79,8 @@ static std::string GetGameHashCodeForImage(CDImage* cdi);
 static std::string GetExecutableNameForImage(CDImage* cdi);
 static void UpdatePerGameMemoryCards();
 
-static bool DoLoadState(ByteStream* stream, bool force_software_renderer, bool update_display, bool is_memory_state);
+static bool DoLoadState(ByteStream* stream, bool force_software_renderer, bool update_display, bool is_memory_state,
+                        const char* media_path = nullptr, uint32_t media_subimage_index = 0);
 static bool DoState(StateWrapper& sw, HostDisplayTexture** host_texture, bool update_display, bool is_memory_state);
 static void DoRunFrame();
 static bool CreateGPU(GPURenderer renderer);
@@ -954,15 +955,16 @@ void Reset()
   g_gpu->ResetGraphicsAPIState();
 }
 
-bool LoadState(ByteStream* state, bool is_memory_state)
+bool LoadState(ByteStream* state, bool is_memory_state, const char* media_path, uint32_t media_subimage_index)
 {
   if (IsShutdown())
     return false;
 
-  return DoLoadState(state, false, false, is_memory_state);
+  return DoLoadState(state, false, false, is_memory_state, media_path, media_subimage_index);
 }
 
-bool DoLoadState(ByteStream* state, bool force_software_renderer, bool update_display, bool is_memory_state)
+bool DoLoadState(ByteStream* state, bool force_software_renderer, bool update_display, bool is_memory_state,
+                 const char* media_path, uint32_t media_subimage_index)
 {
   SAVE_STATE_HEADER header;
   if (!state->Read2(&header, sizeof(header)))
@@ -992,39 +994,40 @@ bool DoLoadState(ByteStream* state, bool force_software_renderer, bool update_di
   Common::Error error;
   std::string media_filename;
   std::unique_ptr<CDImage> media;
+  if (media_path)
+  {
+    media_filename = media_path;
+    header.media_filename_length = static_cast<uint32_t>(media_filename.size());
+    header.media_subimage_index = media_subimage_index;
+  }
   if (header.media_filename_length > 0)
   {
-    media_filename.resize(header.media_filename_length);
-    if (!state->SeekAbsolute(header.offset_to_media_filename) ||
-        !state->Read2(media_filename.data(), header.media_filename_length))
+    if (!media_path)
     {
-      return false;
+      if (header.media_filename_length > state->GetSize())
+        return false;
+      media_filename.resize(header.media_filename_length);
+      if (!state->SeekAbsolute(header.offset_to_media_filename) ||
+          !state->Read2(media_filename.data(), header.media_filename_length))
+      {
+        return false;
+      }
     }
 
-    std::unique_ptr<CDImage> old_media = g_cdrom.RemoveMedia(false);
-    if (old_media && old_media->GetFileName() == media_filename)
+    if (g_cdrom.HasMedia() && g_cdrom.GetMediaFileName() == media_filename)
     {
       Log_InfoPrintf("Re-using same media '%s'", media_filename.c_str());
-      media = std::move(old_media);
+      media = g_cdrom.RemoveMedia(false);
     }
     else
     {
       media = OpenCDImage(media_filename.c_str(), &error, false, ShouldCheckForImagePatches());
       if (!media)
       {
-        if (old_media)
-        {
-          Log_InfoPrintf("Failed to open CD image from save state '%s': %s. Using existing image '%s', this may result in instability.",
-                         media_filename.c_str(), error.GetCodeAndMessage().GetCharArray(), old_media->GetFileName().c_str());
-          media = std::move(old_media);
-        }
-        else
-        {
-          g_host_interface->ReportFormattedError(
-            g_host_interface->TranslateString("System", "Failed to open CD image '%s' used by save state: %s."),
-            media_filename.c_str(), error.GetCodeAndMessage().GetCharArray());
-          return false;
-        }
+        g_host_interface->ReportFormattedError(
+          g_host_interface->TranslateString("System", "Failed to open CD image '%s' used by save state: %s."),
+          media_filename.c_str(), error.GetCodeAndMessage().GetCharArray());
+        return false;
       }
     }
   }

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -91,7 +91,8 @@ bool Boot(const SystemBootParameters& params);
 void Reset();
 void Shutdown();
 
-bool LoadState(ByteStream* state, bool is_memory_state = false);
+bool LoadState(ByteStream* state, bool is_memory_state = false, const char* media_path = nullptr,
+               uint32_t media_subimage_index = 0);
 bool SaveState(ByteStream* state);
 
 /// Recreates the GPU component, saving/loading the state so it is preserved. Call when the GPU renderer changes.

--- a/src/libretro/libretro_host_interface.cpp
+++ b/src/libretro/libretro_host_interface.cpp
@@ -1,5 +1,6 @@
 #include "core/host_interface.h"
 #include "common/byte_stream.h"
+#include "common/cd_image.h"
 #include "common/file_system.h"
 #include "common/log.h"
 #include "common/make_array.h"
@@ -16,6 +17,7 @@
 #include "core/negcon_rumble.h"
 #include "core/pad.h"
 #include "core/playstation_mouse.h"
+#include "core/save_state_version.h"
 #include "core/system.h"
 #include "libretro_audio_stream.h"
 #include "libretro_game_settings.h"
@@ -35,6 +37,49 @@
 #include <vfs/vfs_hybrid.h>
 
 Log_SetChannel(HostInterface);
+
+namespace {
+constexpr uint64_t DISK_STATE_MAGIC = UINT64_C(0x435349444e415753);
+constexpr uint32_t DISK_STATE_VERSION = 1;
+constexpr uint32_t DISK_STATE_EJECTED = 1;
+constexpr uint32_t DISK_STATE_NO_DISC = 2;
+constexpr uint32_t DISK_STATE_CONTAINER = 4;
+
+struct DiskStateHeader
+{
+  uint64_t magic;
+  uint32_t version;
+  uint32_t flags;
+  uint32_t index;
+  uint32_t path_length;
+};
+
+std::optional<uint32_t> FindDiskImage(const HostInterface::DiskControlInfo& info, const std::string& path,
+                                      uint32_t preferred_index)
+{
+  if (preferred_index < info.image_count && info.image_paths[preferred_index] == path)
+    return preferred_index;
+
+  for (uint32_t i = 0; i < info.image_count; i++)
+  {
+    if (info.image_paths[i] == path)
+      return i;
+  }
+
+  std::optional<uint32_t> match;
+  const std::string filename = FileSystem::GetDisplayNameFromPath(path);
+  for (uint32_t i = 0; i < info.image_count; i++)
+  {
+    if (!info.image_paths[i].empty() && FileSystem::GetDisplayNameFromPath(info.image_paths[i]) == filename)
+    {
+      if (match.has_value())
+        return std::nullopt;
+      match = i;
+    }
+  }
+  return match;
+}
+} // namespace
 
 #ifdef WIN32
 #include "core/gpu_hw_d3d11.h"
@@ -929,12 +974,120 @@ size_t HostInterface::retro_serialize_size()
 
 bool HostInterface::retro_serialize(void* data, size_t size)
 {
+  if (!data || size > UINT32_MAX)
+    return false;
   std::unique_ptr<ByteStream> stream = ByteStream_CreateMemoryStream(data, static_cast<uint32_t>(size));
-  return System::SaveState(stream.get());
+  if (!System::SaveState(stream.get()))
+    return false;
+
+  const DiskControlInfo& info = m_disk_control_info;
+  const bool no_disc = info.image_index >= info.image_count;
+  const std::string path = no_disc ? std::string() : info.image_paths[info.image_index];
+  const DiskStateHeader header{DISK_STATE_MAGIC, DISK_STATE_VERSION,
+                               (info.ejected ? DISK_STATE_EJECTED : 0u) | (no_disc ? DISK_STATE_NO_DISC : 0u) |
+                                 (info.has_sub_images ? DISK_STATE_CONTAINER : 0u),
+                               info.image_index, static_cast<uint32_t>(path.size())};
+  return stream->Write2(&header, sizeof(header)) && stream->Write2(path.data(), header.path_length);
 }
 
 bool HostInterface::retro_unserialize(const void* data, size_t size)
 {
+  if (!data || size < sizeof(SAVE_STATE_HEADER) || size > UINT32_MAX)
+    return false;
+
+  SAVE_STATE_HEADER state_header;
+  std::memcpy(&state_header, data, sizeof(state_header));
+  if (state_header.magic != SAVE_STATE_MAGIC || state_header.data_compression_type != 0)
+    return false;
+
+  const uint64_t data_end = static_cast<uint64_t>(state_header.offset_to_data) + state_header.data_uncompressed_size;
+  if (data_end > size)
+    return false;
+
+  DiskControlInfo& info = m_disk_control_info;
+  uint32_t selected_index = info.image_index;
+  bool ejected = state_header.media_filename_length == 0;
+  std::string media_path;
+  const char* media_override = nullptr;
+  uint32_t media_subimage_index = 0;
+  uint64_t trailer_magic = 0;
+  if (size - data_end >= sizeof(trailer_magic))
+    std::memcpy(&trailer_magic, static_cast<const uint8_t*>(data) + data_end, sizeof(trailer_magic));
+
+  // Older cores stop at the machine payload and ignore this optional trailer.
+  if (trailer_magic == DISK_STATE_MAGIC)
+  {
+    if (size - data_end < sizeof(DiskStateHeader))
+      return false;
+    DiskStateHeader header;
+    std::memcpy(&header, static_cast<const uint8_t*>(data) + data_end, sizeof(header));
+    if (header.version != DISK_STATE_VERSION || (header.flags & ~7u) != 0 ||
+        header.path_length > size - data_end - sizeof(header))
+      return false;
+
+    std::string path(reinterpret_cast<const char*>(data) + data_end + sizeof(header), header.path_length);
+    const bool no_disc = (header.flags & DISK_STATE_NO_DISC) != 0;
+    ejected = (header.flags & DISK_STATE_EJECTED) != 0;
+    if (path.find('\0') != std::string::npos || no_disc != path.empty() ||
+        (state_header.media_filename_length != 0) != (!no_disc && !ejected))
+      return false;
+
+    if (no_disc)
+      selected_index = info.image_count;
+    else
+    {
+      if (((header.flags & DISK_STATE_CONTAINER) != 0) != info.has_sub_images)
+        return false;
+      const std::optional<uint32_t> index = FindDiskImage(info, path, header.index);
+      if (!index.has_value())
+        return false;
+      selected_index = index.value();
+      if (!ejected)
+      {
+        media_path = info.has_sub_images ? info.sub_images_parent_path : info.image_paths[selected_index];
+        media_subimage_index = info.has_sub_images ? selected_index : 0;
+      }
+    }
+    media_override = media_path.c_str();
+  }
+  else if (state_header.media_filename_length != 0)
+  {
+    if (static_cast<uint64_t>(state_header.offset_to_media_filename) + state_header.media_filename_length > size)
+      return false;
+    std::string path(static_cast<const char*>(data) + state_header.offset_to_media_filename,
+                     state_header.media_filename_length);
+    if (path.find('\0') != std::string::npos)
+      return false;
+
+    if (!info.sub_images_parent_path.empty() &&
+        FileSystem::GetDisplayNameFromPath(path) == FileSystem::GetDisplayNameFromPath(info.sub_images_parent_path))
+    {
+      if (info.has_sub_images)
+      {
+        if (state_header.media_subimage_index >= info.image_count)
+          return false;
+        path = info.image_paths[state_header.media_subimage_index];
+      }
+      else
+      {
+        std::unique_ptr<CDImage> playlist =
+          CDImage::Open(info.sub_images_parent_path.c_str(), CDImage::OpenFlags::None, nullptr);
+        if (!playlist || !playlist->HasSubImages() || state_header.media_subimage_index >= playlist->GetSubImageCount())
+          return false;
+        path = playlist->GetSubImageMetadata(state_header.media_subimage_index, "file_path");
+      }
+    }
+    else if (state_header.media_subimage_index != 0 || info.has_sub_images)
+      return false;
+
+    const std::optional<uint32_t> index = FindDiskImage(info, path, state_header.media_subimage_index);
+    if (!index.has_value())
+      return false;
+    selected_index = index.value();
+    media_path = info.has_sub_images ? info.sub_images_parent_path : info.image_paths[selected_index];
+    media_subimage_index = info.has_sub_images ? selected_index : 0;
+    media_override = media_path.c_str();
+  }
   // Ask the frontend whether this load is for runahead / rewind / netplay
   // rollback or a normal disk load. The runahead flavours guarantee the
   // state was produced by the same binary in the same address space, so
@@ -952,7 +1105,10 @@ bool HostInterface::retro_unserialize(const void* data, size_t size)
   }
 
   std::unique_ptr<ByteStream> stream = ByteStream_CreateReadOnlyMemoryStream(data, static_cast<uint32_t>(size));
-  return System::LoadState(stream.get(), is_memory_state);
+  if (!System::LoadState(stream.get(), is_memory_state, media_override, media_subimage_index))
+    return false;
+
+  return true;
 }
 
 void* HostInterface::retro_get_memory_data(unsigned id)


### PR DESCRIPTION
## Description

Restore the frontend's selected disc when loading a save state.

Previously, loading a state restored the CD-ROM media but left the libretro disk-control index unchanged. For M3U playlists, save states also stored only the playlist path and subimage index, so editing or reordering the playlist could cause a state to restore a different disc.

Save states now include an optional disk-control trailer containing the selected image path, index and tray state. When loading, the saved path is matched against the current disc list, with a unique filename match used as a fallback for moved images.

Missing or ambiguous matches are rejected instead of leaving the frontend's selected index and the mounted media out of sync.

The existing machine-state payload is unchanged, so older cores can ignore the trailer and existing save states remain supported.

## Motivation and context

The libretro disk-control state needs to stay synchronized with the media restored by a save state. Numeric playlist indices alone are not sufficient because playlist contents can be reordered or edited between saving and loading.

## How has this been tested?

Tested with Metal Gear Solid across all disc and tray combinations, including:

* Loading after playlist edits
* Reordered playlist entries
* Moved disc images
* Missing and ambiguous images
* Malformed disk-state trailers
* Existing save states created before this change

Old M3U states continue to load, subject to the existing limitation that their numeric subimage index cannot identify the original disc after the playlist itself has been reordered.

## What is the effect on users?

Save states now restore the intended disc and frontend disk selection more reliably, including when playlist images have moved or the playlist has changed.